### PR TITLE
Corrected check digit calculation for TD1 documents with optional dat…

### DIFF
--- a/src/MRZ/Parser.cs
+++ b/src/MRZ/Parser.cs
@@ -137,7 +137,7 @@ namespace MRZ
                     computeWeightedSum(line1, 5, 29, 0);
                     computeWeightedSum(line2, 0, 6, 25);
                     computeWeightedSum(line2, 8, 14, 32);
-                    computeWeightedSum(line2, 18, 28, 43);
+                    computeWeightedSum(line2, 18, 28, 39);
 
                     if ((sum % 10) != mappedValues[line2[29]])
                         throw new Exception("upper and middle lines check failed");

--- a/src/Test/UnitTest.cs
+++ b/src/Test/UnitTest.cs
@@ -47,6 +47,25 @@ CARLOS<MONTEIRO<<AMELIA<VANESS");
             Assert.AreEqual(doc.OptionalData2, string.Empty, "Wrong document optional data 2");
             Assert.AreEqual(doc.Surname, "CARLOS MONTEIRO", "Wrong surname");
             Assert.AreEqual(doc.Name, "AMELIA VANESS", "Wrong name");
+
+            doc = parser.DetectFields(
+@"IPUSAC030049646<<10<30<B22<498
+8101017M1911297USA<<0754052296
+TRAVELER<<HAPPY<<<<<<<<<<<<<<<");
+
+            Assert.AreEqual(doc.Format, MrzFormat.TD1, "Wrong document format");
+            Assert.AreEqual(doc.Type, "IP", "Wrong document type");
+            Assert.AreEqual(doc.CountryCode, "USA", "Wrong document country code");
+            Assert.AreEqual(doc.Number, "C03004964", "Wrong document number");
+            Assert.AreEqual(doc.OptionalData1, "10<30<B22<498", "Wrong document optional data 1");
+            Assert.AreEqual(doc.BirthDate, new DateTime(1981, 01, 01), "Wrong birth date");
+            Assert.AreEqual(doc.Gender, Gender.Male, "Wrong gender");
+            Assert.AreEqual(doc.ExpirationDate, new DateTime(2019, 11, 29), "Wrong expiration date");
+            Assert.AreEqual(doc.Nationality, "USA", "Wrong nationality country code");
+            Assert.AreEqual(doc.OptionalData2, "075405229", "Wrong document optional data 2");
+            Assert.AreEqual(doc.Surname, "TRAVELER", "Wrong surname");
+            Assert.AreEqual(doc.Name, "HAPPY", "Wrong name");
+
         }
 
         [TestMethod]


### PR DESCRIPTION
This corrects a check sum calculation error where the weight on the 19th digit on line 2 was set at 3 instead of 7. This would cause an issue in which the validation would fail if optional data was supplied on Line 2. (Issue #1 )

A unit test with other data has passed.